### PR TITLE
Update argocd CR

### DIFF
--- a/helm/cicd/templates/argocd.yaml
+++ b/helm/cicd/templates/argocd.yaml
@@ -5,8 +5,12 @@ metadata:
   name: argocd
   namespace: {{ .Values.demoNamespace }}
 spec:
-  dex:
-    openShiftOAuth: true
+  sso:
+    dex:
+      openShiftOAuth: true
+    provider: dex
+  notifications:
+    enabled: true
   rbac:
     policy: |
       g, system:cluster-admins, role:admin


### PR DESCRIPTION
ArgoCD CR changed in Gitops 1.6. Updating to comply with latest CR.