### PR TITLE
Update Dockerfile to change JBoss WebServer version

### DIFF
--- a/customers-tomcat-gitops/Dockerfile
+++ b/customers-tomcat-gitops/Dockerfile
@@ -1,3 +1,3 @@
-FROM image-registry.openshift-image-registry.svc:5000/openshift/jboss-webserver56-openjdk11-tomcat9-openshift-ubi8
+FROM image-registry.openshift-image-registry.svc:5000/openshift/jboss-webserver57-openjdk11-tomcat9-openshift-ubi8
 
 COPY target/*.war /deployments


### PR DESCRIPTION
5.6 doesn't exist on OCP 4.13 anymore. Changing to 5.7